### PR TITLE
Remove pydantic fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "python_opensky",
   "version": "0.0.0",
   "private": true,
-  "description": "Asynchronous Python client providing RDW vehicle information",
+  "description": "Asynchronous Python client for Opensky API",
   "scripts": {
     "prettier": "prettier --write **/*.{json,js,md,yml,yaml}"
   },
-  "author": "Franck Nijhof <opensource@frenck.dev>",
+  "author": "Joost Lekkerkerker <joostlek@outlook.com>",
   "license": "MIT",
   "devDependencies": {
     "prettier": "3.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python_opensky"
-version = "0.1.0"
+version = "0.2.1"
 description = "Asynchronous Python client for Opensky API."
 authors = ["Joost Lekkerkerker <joostlek@outlook.com>"]
 maintainers = ["Joost Lekkerkerker <joostlek@outlook.com>"]

--- a/src/python_opensky/models.py
+++ b/src/python_opensky/models.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-try:
-    from pydantic.v1 import BaseModel, Field
-except ImportError:  # pragma: no cover
-    from pydantic import BaseModel, Field  # type: ignore[assignment] # pragma: no cover
+from pydantic import BaseModel, Field
 
 from .const import AircraftCategory, PositionSource
 from .exceptions import OpenSkyCoordinateError


### PR DESCRIPTION
Apparently BaseModel and Field aren't changed so we can just keep using the v2 ones.