### PR TITLE
feat: Replace BasicAuth with OAuth2 client credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ from python_opensky import OpenSky, StatesResponse
 async def main() -> None:
     """Show example of fetching all flight states."""
     async with OpenSky() as opensky:
+        # Optional: authenticate for higher rate limits
+        # await opensky.authenticate(
+        #     client_id="your_client_id",
+        #     client_secret="your_client_secret",
+        # )
         states: StatesResponse = await opensky.get_states()
         print(states)
 

--- a/src/python_opensky/const.py
+++ b/src/python_opensky/const.py
@@ -46,3 +46,6 @@ MIN_LATITUDE = "lamin"
 MAX_LATITUDE = "lamax"
 MIN_LONGITUDE = "lomin"
 MAX_LONGITUDE = "lomax"
+
+TOKEN_URL = "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token"  # noqa: S105
+TOKEN_REFRESH_MARGIN = 30

--- a/src/python_opensky/opensky.py
+++ b/src/python_opensky/opensky.py
@@ -10,11 +10,18 @@ from datetime import UTC, datetime, timedelta
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, cast
 
-from aiohttp import BasicAuth, ClientError, ClientResponseError, ClientSession
-from aiohttp.hdrs import METH_GET
+from aiohttp import ClientError, ClientResponseError, ClientSession
+from aiohttp.hdrs import METH_GET, METH_POST
 from yarl import URL
 
-from .const import MAX_LATITUDE, MAX_LONGITUDE, MIN_LATITUDE, MIN_LONGITUDE
+from .const import (
+    MAX_LATITUDE,
+    MAX_LONGITUDE,
+    MIN_LATITUDE,
+    MIN_LONGITUDE,
+    TOKEN_REFRESH_MARGIN,
+    TOKEN_URL,
+)
 from .exceptions import (
     OpenSkyConnectionError,
     OpenSkyError,
@@ -30,6 +37,16 @@ VERSION = metadata.version(__package__)
 
 
 @dataclass
+class _OAuthSession:
+    """OAuth2 client credentials and the access token they hold."""
+
+    client_id: str
+    client_secret: str
+    token: str | None = None
+    expires_at: datetime | None = None
+
+
+@dataclass
 class OpenSky:
     """Main class for handling connections with OpenSky."""
 
@@ -40,21 +57,23 @@ class OpenSky:
     timezone = UTC
     _close_session: bool = False
     _credit_usage: dict[datetime, int] = field(default_factory=dict)
-    _auth: BasicAuth | None = None
+    _oauth: _OAuthSession | None = None
     _contributing_user: bool = False
 
     async def authenticate(
         self,
-        auth: BasicAuth,
+        client_id: str,
+        client_secret: str,
         *,
         contributing_user: bool = False,
     ) -> None:
         """Authenticate the user."""
-        self._auth = auth
+        self._oauth = _OAuthSession(client_id=client_id, client_secret=client_secret)
         try:
+            await self._refresh_token()
             await self.get_states(bounding_box=BoundingBox(0.0, 0.0, 1.0, 1.0))
         except OpenSkyUnauthenticatedError as exc:
-            self._auth = None
+            self._oauth = None
             raise OpenSkyUnauthenticatedError from exc
         self._contributing_user = contributing_user
         if contributing_user:
@@ -70,7 +89,64 @@ class OpenSky:
     @property
     def is_authenticated(self) -> bool:
         """Return if the user is correctly authenticated."""
-        return self._auth is not None
+        return self._oauth is not None
+
+    async def _refresh_token(self) -> None:
+        """Refresh the OAuth2 access token."""
+        assert self._oauth is not None  # noqa: S101 — callers guard
+        if self.session is None:
+            self.session = ClientSession()
+            self._close_session = True
+
+        try:
+            async with asyncio.timeout(self.request_timeout):
+                response = await self.session.request(
+                    METH_POST,
+                    TOKEN_URL,
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": self._oauth.client_id,
+                        "client_secret": self._oauth.client_secret,
+                    },
+                )
+        except TimeoutError as exception:
+            msg = "Timeout occurred while connecting to the OpenSky API"
+            raise OpenSkyConnectionError(msg) from exception
+        except (
+            ClientError,
+            ClientResponseError,
+            socket.gaierror,
+        ) as exception:
+            msg = "Error occurred while communicating with OpenSky API"
+            raise OpenSkyConnectionError(msg) from exception
+
+        if response.status == 401:
+            raise OpenSkyUnauthenticatedError
+
+        try:
+            response.raise_for_status()
+        except ClientResponseError as exception:
+            msg = "Error occurred while communicating with OpenSky API"
+            raise OpenSkyConnectionError(msg) from exception
+
+        token_data = await response.json()
+        self._oauth.token = token_data["access_token"]
+        self._oauth.expires_at = datetime.now(UTC) + timedelta(
+            seconds=token_data["expires_in"] - TOKEN_REFRESH_MARGIN,
+        )
+
+    async def _get_access_token(self) -> str | None:
+        """Get a valid access token, refreshing if needed."""
+        if self._oauth is None:
+            return None
+        if (
+            self._oauth.token
+            and self._oauth.expires_at
+            and self._oauth.expires_at > datetime.now(UTC)
+        ):
+            return self._oauth.token
+        await self._refresh_token()
+        return self._oauth.token
 
     async def _request(
         self,
@@ -116,12 +192,15 @@ class OpenSky:
             self.session = ClientSession()
             self._close_session = True
 
+        token = await self._get_access_token()
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+
         try:
             async with asyncio.timeout(self.request_timeout):
                 response = await self.session.request(
                     METH_GET,
                     url.with_query(data),
-                    auth=self._auth,
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -185,7 +264,7 @@ class OpenSky:
 
     async def get_own_states(self, time: int = 0) -> StatesResponse:
         """Retrieve state vectors from your own sensors."""
-        if not self._auth:
+        if self._oauth is None:
             raise OpenSkyUnauthenticatedError
         params = {
             "time": time,

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -2,10 +2,12 @@
 
 import asyncio
 from dataclasses import asdict
+from datetime import UTC, datetime
+from typing import Any
 
 import aiohttp
 import pytest
-from aiohttp import BasicAuth, ClientError
+from aiohttp import ClientError
 from aiohttp.web_request import BaseRequest
 from aresponses import Response, ResponsesMockServer
 from syrupy.assertion import SnapshotAssertion
@@ -22,6 +24,29 @@ from python_opensky.exceptions import OpenSkyUnauthenticatedError
 from . import load_fixture
 
 OPENSKY_URL = "opensky-network.org"
+TOKEN_HOST = "auth.opensky-network.org"  # noqa: S105
+TOKEN_PATH = "/auth/realms/opensky-network/protocol/openid-connect/token"  # noqa: S105
+TOKEN_RESPONSE = '{"access_token": "test-token", "expires_in": 1800}'  # noqa: S105
+
+
+def _add_token_mock(
+    aresponses: ResponsesMockServer,
+    *,
+    repeat: int = 1,
+    status: int = 200,
+) -> None:
+    """Add a token endpoint mock."""
+    aresponses.add(
+        TOKEN_HOST,
+        TOKEN_PATH,
+        "POST",
+        aresponses.Response(
+            status=status,
+            headers={"Content-Type": "application/json"},
+            text=TOKEN_RESPONSE,
+        ),
+        repeat=repeat,
+    )
 
 
 async def test_states(
@@ -73,6 +98,7 @@ async def test_own_states(
     aresponses: ResponsesMockServer,
 ) -> None:
     """Test retrieving own states."""
+    _add_token_mock(aresponses)
     aresponses.add(
         OPENSKY_URL,
         "/api/states/all",
@@ -96,7 +122,8 @@ async def test_own_states(
     async with aiohttp.ClientSession() as session:
         opensky = OpenSky(session=session)
         await opensky.authenticate(
-            BasicAuth(login="test", password="test"),
+            client_id="test_id",
+            client_secret="test_secret",
             contributing_user=True,
         )
         response: StatesResponse = await opensky.get_own_states()
@@ -110,6 +137,7 @@ async def test_unavailable_own_states(
     aresponses: ResponsesMockServer,
 ) -> None:
     """Test retrieving no own states."""
+    _add_token_mock(aresponses)
     aresponses.add(
         OPENSKY_URL,
         "/api/states/all",
@@ -133,7 +161,8 @@ async def test_unavailable_own_states(
     async with aiohttp.ClientSession() as session:
         opensky = OpenSky(session=session)
         await opensky.authenticate(
-            BasicAuth(login="test", password="test"),
+            client_id="test_id",
+            client_secret="test_secret",
             contributing_user=True,
         )
         response: StatesResponse = await opensky.get_own_states()
@@ -236,12 +265,13 @@ async def test_timeout(aresponses: ResponsesMockServer) -> None:
 
 async def test_auth(aresponses: ResponsesMockServer) -> None:
     """Test request authentication."""
+    _add_token_mock(aresponses, repeat=1)
 
     def response_handler(request: BaseRequest) -> Response:
         """Response handler for this test."""
         assert request.headers
         assert request.headers["Authorization"]
-        assert request.headers["Authorization"] == "Basic dGVzdDp0ZXN0"
+        assert request.headers["Authorization"] == "Bearer test-token"
         return aresponses.Response(
             status=200,
             headers={"Content-Type": "application/json"},
@@ -258,7 +288,10 @@ async def test_auth(aresponses: ResponsesMockServer) -> None:
 
     async with aiohttp.ClientSession() as session:
         opensky = OpenSky(session=session)
-        await opensky.authenticate(BasicAuth(login="test", password="test"))
+        await opensky.authenticate(
+            client_id="test_id",
+            client_secret="test_secret",
+        )
         await opensky.get_states()
         await opensky.close()
 
@@ -266,20 +299,23 @@ async def test_auth(aresponses: ResponsesMockServer) -> None:
 async def test_unauthorized(aresponses: ResponsesMockServer) -> None:
     """Test request authentication."""
     aresponses.add(
-        OPENSKY_URL,
-        "/api/states/all",
-        "GET",
+        TOKEN_HOST,
+        TOKEN_PATH,
+        "POST",
         aresponses.Response(
             status=401,
             headers={"Content-Type": "application/json"},
-            text=load_fixture("states.json"),
+            text="{}",
         ),
     )
 
     async with aiohttp.ClientSession() as session:
         opensky = OpenSky(session=session)
         try:
-            await opensky.authenticate(BasicAuth(login="test", password="test"))
+            await opensky.authenticate(
+                client_id="test_id",
+                client_secret="test_secret",
+            )
             pytest.fail("Should've thrown exception")
         except OpenSkyUnauthenticatedError:
             pass
@@ -289,6 +325,7 @@ async def test_unauthorized(aresponses: ResponsesMockServer) -> None:
 
 async def test_user_credits(aresponses: ResponsesMockServer) -> None:
     """Test authenticated user credits."""
+    _add_token_mock(aresponses, repeat=2)
     aresponses.add(
         OPENSKY_URL,
         "/api/states/all",
@@ -303,10 +340,14 @@ async def test_user_credits(aresponses: ResponsesMockServer) -> None:
     async with aiohttp.ClientSession() as session:
         opensky = OpenSky(session=session)
         assert opensky.opensky_credits == 400
-        await opensky.authenticate(BasicAuth(login="test", password="test"))
+        await opensky.authenticate(
+            client_id="test_id",
+            client_secret="test_secret",
+        )
         assert opensky.opensky_credits == 4000
         await opensky.authenticate(
-            BasicAuth(login="test", password="test"),
+            client_id="test_id",
+            client_secret="test_secret",
             contributing_user=True,
         )
         assert opensky.opensky_credits == 8000
@@ -397,3 +438,144 @@ async def test_calculating_credit_usage() -> None:
         max_longitude=10.9,
     )
     assert opensky.calculate_credit_costs(bounding_box) == 4
+
+
+async def test_token_refresh(aresponses: ResponsesMockServer) -> None:
+    """Test that token is refreshed when expired."""
+    _add_token_mock(aresponses, repeat=2)
+    aresponses.add(
+        OPENSKY_URL,
+        "/api/states/all",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("states.json"),
+        ),
+        repeat=2,
+    )
+    async with aiohttp.ClientSession() as session:
+        opensky = OpenSky(session=session)
+        await opensky.authenticate(
+            client_id="test_id",
+            client_secret="test_secret",
+        )
+        # Expire the token
+        assert opensky._oauth is not None  # noqa: SLF001
+        opensky._oauth.expires_at = datetime(2020, 1, 1, tzinfo=UTC)  # noqa: SLF001
+        await opensky.get_states()
+        await opensky.close()
+
+
+async def test_token_refresh_new_session(aresponses: ResponsesMockServer) -> None:
+    """Test that _refresh_token creates a session if none exists."""
+    _add_token_mock(aresponses)
+    aresponses.add(
+        OPENSKY_URL,
+        "/api/states/all",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("states.json"),
+        ),
+    )
+    async with OpenSky() as opensky:
+        await opensky.authenticate(
+            client_id="test_id",
+            client_secret="test_secret",
+        )
+        assert opensky.session
+
+
+async def test_token_refresh_timeout(aresponses: ResponsesMockServer) -> None:
+    """Test token refresh timeout."""
+
+    async def response_handler(_: BaseRequest) -> Response:
+        await asyncio.sleep(2)
+        return aresponses.Response(body="Timeout")
+
+    aresponses.add(
+        TOKEN_HOST,
+        TOKEN_PATH,
+        "POST",
+        response_handler,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        opensky = OpenSky(session=session, request_timeout=1)
+        with pytest.raises(OpenSkyConnectionError):
+            await opensky.authenticate(
+                client_id="test_id",
+                client_secret="test_secret",
+            )
+        await opensky.close()
+
+
+async def test_token_refresh_connection_error() -> None:
+    """Test token refresh connection error."""
+    async with aiohttp.ClientSession() as session:
+        opensky = OpenSky(session=session)
+        # Patch session.request to raise ClientError
+        original_request = session.request
+
+        async def mock_request(*_args: Any, **_kwargs: Any) -> None:
+            raise ClientError
+
+        session.request = mock_request  # type: ignore[assignment]
+        with pytest.raises(OpenSkyConnectionError):
+            await opensky.authenticate(
+                client_id="test_id",
+                client_secret="test_secret",
+            )
+        session.request = original_request  # type: ignore[assignment]
+        await opensky.close()
+
+
+async def test_token_refresh_server_error(
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test token refresh with server error response."""
+    aresponses.add(
+        TOKEN_HOST,
+        TOKEN_PATH,
+        "POST",
+        aresponses.Response(
+            status=500,
+            headers={"Content-Type": "application/json"},
+            text="{}",
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        opensky = OpenSky(session=session)
+        with pytest.raises(OpenSkyConnectionError):
+            await opensky.authenticate(
+                client_id="test_id",
+                client_secret="test_secret",
+            )
+        await opensky.close()
+
+
+async def test_api_returns_401(aresponses: ResponsesMockServer) -> None:
+    """Test that a 401 from the API raises OpenSkyUnauthenticatedError."""
+    _add_token_mock(aresponses)
+    aresponses.add(
+        OPENSKY_URL,
+        "/api/states/all",
+        "GET",
+        aresponses.Response(
+            status=401,
+            headers={"Content-Type": "application/json"},
+            text="{}",
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        opensky = OpenSky(session=session)
+        with pytest.raises(OpenSkyUnauthenticatedError):
+            await opensky.authenticate(
+                client_id="test_id",
+                client_secret="test_secret",
+            )
+        assert opensky.is_authenticated is False
+        await opensky.close()


### PR DESCRIPTION
Firstly -- Thank you for making this repo and open source. I use it for home assistant because I didn't want to set up my own software defined antenna. 

OpenSky Network dropped basic authentication on March 18, 2026 and now exclusively uses OAuth2 client credentials. This updates the authenticate() method to accept client_id and client_secret instead of BasicAuth, with automatic token refresh. ([API docs](https://openskynetwork.github.io/opensky-api/rest.html#authentication)).

Currently, `python-opensky` uses `aiohttp.BasicAuth` in `authenticate()`, which means authenticated requests no longer work. Anonymous access still functions but with reduced rate limits (400 credits/day, 15-minute resolution).

OAuth2 state (credentials + token + expiry) is bundled into a private _OAuthSession dataclass to keep the OpenSky instance attribute count at 8, matching pre-OAuth2.

Ref: openskynetwork/opensky-api#85
Ref: home-assistant/core#156643

# Proposed Changes

- Replace `BasicAuth` with OAuth2 client credentials token exchange
- Token endpoint: `https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token`
- `authenticate()` accepts `client_id` and `client_secret` instead of `BasicAuth`
- Tokens auto-refresh before expiry (30-minute lifetime, 30s refresh margin)
- Anonymous access unchanged

## Related Issues

- None - I think it's in the home-assistant/core#156643


## Additional disclosure

AI was used in the crafting of this PR, however, I personally validated the code and tested it. 

## Testing Done

## Live Integration Test (2026-06-07)

(Note: Once this is merged I can test the HA integration itself)

### Test Script

Save as `integration_test.py` and run from the repo root with `uv run python integration_test.py`. Authenticated section runs only if `OPENSKY_CLIENT_ID` and `OPENSKY_CLIENT_SECRET` are set.

```python
"""Live integration test against the OpenSky API.

Anonymous always runs. Authenticated runs only if OPENSKY_CLIENT_ID and
OPENSKY_CLIENT_SECRET are set.
"""

import asyncio
import os
import sys

from python_opensky import BoundingBox, OpenSky


async def main() -> int:
    seattle = BoundingBox(
        min_latitude=47.0,
        max_latitude=48.0,
        min_longitude=-123.0,
        max_longitude=-122.0,
    )

    print("=== Anonymous ===")
    async with OpenSky() as opensky:
        states = await opensky.get_states(bounding_box=seattle)
        print(f"  is_authenticated: {opensky.is_authenticated}")
        print(f"  credits: {opensky.opensky_credits}")
        print(f"  aircraft found: {len(states.states)}")
        for s in states.states[:3]:
            print(f"    {s.icao24} {s.callsign or '':<8} alt={s.geo_altitude}m")

    client_id = os.environ.get("OPENSKY_CLIENT_ID")
    client_secret = os.environ.get("OPENSKY_CLIENT_SECRET")
    if not (client_id and client_secret):
        print("\n(Skipping authenticated test — set OPENSKY_CLIENT_ID/SECRET to run)")
        return 0

    print("\n=== Authenticated (OAuth2) ===")
    async with OpenSky() as opensky:
        print(f"  before: is_auth={opensky.is_authenticated} credits={opensky.opensky_credits}")
        await opensky.authenticate(client_id=client_id, client_secret=client_secret)
        print(f"  after:  is_auth={opensky.is_authenticated} credits={opensky.opensky_credits}")
        states = await opensky.get_states(bounding_box=seattle)
        print(f"  remaining credits: {opensky.remaining_credits()}")
        print(f"  aircraft found: {len(states.states)}")
        for s in states.states[:3]:
            print(f"    {s.icao24} {s.callsign or '':<8} alt={s.geo_altitude}m")

    return 0


if __name__ == "__main__":
    sys.exit(asyncio.run(main()))
```

### Output (live OpenSky API, Seattle bounding box)

```
=== Anonymous ===
  is_authenticated: False
  credits: 400
  aircraft found: 14
    abae62 SWA286   alt=3779.52m
    a44213 UAL2379  alt=1501.14m
    ad2ea1 ASA727   alt=2750.82m

=== Authenticated (OAuth2) ===
  before: is_auth=False credits=400
  after:  is_auth=True credits=4000
  remaining credits: 3998
  aircraft found: 14
    abae62 SWA286   alt=3779.52m
    a44213 UAL2379  alt=1501.14m
    ad2ea1 ASA727   alt=2750.82m
```

### Observations

- **Anonymous tier:** 400 credits/day, request succeeds without auth
- **Authenticated tier:** 4000 credits/day (10× anonymous), confirms paid client tier
- **Token exchange:** POST to `https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token` returns access token; library transitions `is_authenticated` False → True
- **Bearer auth:** subsequent `/api/states/all` request uses `Authorization: Bearer <token>` header (replaces removed BasicAuth)
- **Credit accounting:** `remaining_credits()` returns 3998 — bounding box query costs 1 credit and is counted twice in this test (once in the authenticate roundtrip, once in the explicit `get_states` call). Matches expected behavior.

### Local Quality Gates

```
$ uv run ruff check src tests
All checks passed!

$ uv run pytest -q
27 passed in 2.25s
Required test coverage of 100% reached. Total coverage: 100.00%

$ uv run mypy src
Success: no issues found in 6 source files
```